### PR TITLE
Fix/restart to load themes

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,46 +6,40 @@ from views.loading_screen import LoadingScreen
 from utils.menu_themes import MenuThemes
 
 if __name__ == "__main__":
+    
     # Create the main application instance
     app = QApplication(sys.argv)
-    app.setStyle("Fusion")  # Set the default visual style for the application
+    app.setStyle("Fusion")
 
     # Initialize the ThemeManager
     theme_manager = MenuThemes(app, None)
-    stylesheet, image_path, progress_style = theme_manager.load_theme()
-
+    # load the initial theme (without showing notification)
+    stylesheet, image_path, progress_style = theme_manager.load_initial_theme()
     # Apply the loaded stylesheet if available
     if stylesheet:
         app.setStyleSheet(stylesheet)
-
+        
     # Initialize and display the loading screen
     splash = LoadingScreen(progress_style=progress_style)
     splash.show()
-
-    # Simulate the loading process with progress updates
+    # Set message and progress time intervals
     splash.update_progress(10, "Initializing application...")
-    time.sleep(0.3)  # Simulate a delay for initialization
-
+    time.sleep(0.3)
     splash.update_progress(25, "Loading visual theme...")
-    time.sleep(0.3)  # Simulate a delay for theme loading
-
+    time.sleep(0.3)
     splash.update_progress(50, "Setting up the interface...")
-    time.sleep(0.5)  # Simulate a delay for interface setup
-
+    time.sleep(0.5)
     splash.update_progress(75, "Loading components...")
-    time.sleep(0.4)  # Simulate a delay for component loading   
+    time.sleep(0.4)   
 
     # Create the main application window
     browser = SampleBrowser(stylesheet=stylesheet, image_path=image_path)
-    theme_manager.browser = browser  # Set the browser instance in ThemeManager
-    theme_manager.setup_menu()  # Set up the theme menu
-
+    theme_manager.browser = browser # Set the browser instance in ThemeManager
+    theme_manager.setup_menu() # Set up the theme menu
     splash.update_progress(100, "Ready!")
-    time.sleep(0.3)  # Simulate a short delay before finishing
+    time.sleep(0.3) # Simulate a short delay before finishing
 
     # Show the main window and close the loading screen
     browser.show()
     splash.finish(browser)
-
-    # Start the application's event loop
-    sys.exit(app.exec())
+    sys.exit(app.exec()) # Start the application's event loop

--- a/utils/menu_themes.py
+++ b/utils/menu_themes.py
@@ -6,69 +6,78 @@ from utils.helpers import load_theme
 
 class MenuThemes:
     def __init__(self, app, browser):
-        """
-        Initialize the ThemeManager.
-
-        Args:
-            app (QApplication): The main application instance.
-            browser (QMainWindow): The main application window.
-        """
+        # Store references to the main application and browser window
         self.app = app
         self.browser = browser
+        # Persistent settings for saving the selected theme
         self.settings = QSettings("SampleBrowser", "SampleBrowserPro")
+        # List of available theme names
         self.themes = ["dark", "softBlue", "1bitMonitorGlow", "everglowDiamond"]
+        # Flag to track if the theme is being loaded for the first time
+        self.is_initial_load = True
 
     def setup_menu(self):
-        """
-        Set up the menu bar for theme selection.
-        """
+        """Creates the theme selection menu and adds it to the browser's menu bar."""
+        if self.browser is None:
+            return
+            
         menu_bar = QMenuBar(self.browser)
         themes_menu = menu_bar.addMenu("Themes")
 
+        # Add an action for each theme, connecting it to the selection handler
         for theme in self.themes:
             action = themes_menu.addAction(theme)
+            # Use a lambda to pass the theme name to the handler
             action.triggered.connect(lambda checked, t=theme: self.select_theme(t))
 
         self.browser.setMenuBar(menu_bar)
 
     def select_theme(self, selected_theme):
-        """
-        Update the theme, save the selection, and prompt for a restart.
-
-        Args:
-            selected_theme (str): The name of the selected theme.
-        """
+        """Handles user theme selection, saves it, and applies the theme with notification."""
         self.settings.setValue("selected_theme", selected_theme)
+        self.apply_theme(selected_theme, show_notification=True)
 
-        # Show a message box to inform the user
+    def apply_theme(self, theme_name, show_notification=False):
+        """Applies the selected theme to the app and browser, optionally showing a notification."""
+        if self.app is None:
+            return
+            
+        # Load theme resources (stylesheet, image, progress bar style)
+        stylesheet, image_path, progress_style = load_theme(theme_name)
+        
+        # Apply stylesheet to the main app
+        self.app.setStyleSheet(stylesheet)
+        
+        # Apply stylesheet to the browser window if available
+        if self.browser is not None:
+            self.browser.setStyleSheet(stylesheet)
+        
+        # Show notification only if not the initial load and notification is requested
+        if show_notification and not self.is_initial_load:
+            self.show_theme_changed_notification(theme_name)
+
+    def show_theme_changed_notification(self, theme_name):
+        """Displays a message box notifying the user that the theme has changed."""
         msg_box = QMessageBox()
         msg_box.setIcon(QMessageBox.Icon.Information)
-        msg_box.setWindowTitle("Restart Required")
-        msg_box.setText("The application needs to restart to apply the selected theme.")
+        msg_box.setWindowTitle("Theme Changed")
+        msg_box.setText(f"Theme changed to {theme_name} successfully.")
+        # Set window icon using a helper function for resource path
         msg_box.setWindowIcon(QIcon(resource_path("resources/icons/icon.ico")))
-
-        # Apply a specific style to the QMessageBox
-        msg_box.setStyleSheet("""
-            }
-            QMessageBox QLabel {
-                color: #ffffff;
-            }
-        """)
-
         msg_box.setStandardButtons(QMessageBox.StandardButton.Ok)
-        msg_box.exec()  # Show the message box
+        # Use the current app stylesheet for consistency
+        msg_box.setStyleSheet(self.app.styleSheet())
+        msg_box.exec()
 
-        self.app.quit()  # Restart the application to apply the new theme
-
-    def load_theme(self):
-        """
-        Load the last selected theme or default to "dark".
-
-        Returns:
-            tuple: A tuple containing the stylesheet, image path, and progress style.
-        """
+    def load_initial_theme(self):
+        """Loads the initial theme from settings without showing a notification."""
         theme_name = self.settings.value("selected_theme", "dark")
+        # Fallback to default theme if the saved theme is not available
         if theme_name not in self.themes:
-            theme_name = "dark"  # Default to "dark" if the saved theme is not available
-
-        return load_theme(theme_name)
+            theme_name = "dark"
+        
+        self.apply_theme(theme_name)
+        # Mark that the initial load is complete so notifications can be shown later
+        self.is_initial_load = False
+        # Return theme resources for further use if needed
+        return

--- a/utils/menu_themes.py
+++ b/utils/menu_themes.py
@@ -13,57 +13,85 @@ class MenuThemes:
         self.is_initial_load = True
 
     def setup_menu(self):
-        """Configura el menú de temas"""
-        if self.browser is None:
+        """
+        Creates the theme selection menu and adds it to the browser's menu bar.
+        """
+        if self.browser is None:    
             return
             
         menu_bar = QMenuBar(self.browser)
         themes_menu = menu_bar.addMenu("Themes")
 
+        # Add an action for each theme, connecting it to the selection handler
         for theme in self.themes:
             action = themes_menu.addAction(theme)
+            # Use a lambda to pass the theme name to the handler
             action.triggered.connect(lambda checked, t=theme: self.select_theme(t))
 
         self.browser.setMenuBar(menu_bar)
 
     def select_theme(self, selected_theme):
-        """Selección de tema por el usuario (con notificación)"""
+        """
+        Handles user theme selection, saves it, 
+        and applies the theme with notification.
+        """
         self.settings.setValue("selected_theme", selected_theme)
         self.apply_theme(selected_theme, show_notification=True)
 
     def apply_theme(self, theme_name, show_notification=False):
-        """Aplica el tema con opción de mostrar notificación"""
+        """
+        Applies the selected theme to the app and browser, 
+        optionally showing a notification.
+        """
         if self.app is None:
             return
-            
-        stylesheet, image_path, progress_style = load_theme(theme_name)
         
+        # Load theme resources (stylesheet, image, progress bar style)    
+        stylesheet, mage_path, progress_style = load_theme(theme_name)
+        
+        # Apply stylesheet to the main app
         self.app.setStyleSheet(stylesheet)
         
+        # Apply stylesheet to the browser window if available
         if self.browser is not None:
             self.browser.setStyleSheet(stylesheet)
         
-        # Solo muestra notificación si no es la carga inicial y está habilitado
+        # Show notification only if not the initial load and notification is requested
         if show_notification and not self.is_initial_load:
             self.show_theme_changed_notification(theme_name)
 
     def show_theme_changed_notification(self, theme_name):
-        """Muestra notificación de cambio de tema"""
+        """
+        Displays a message box notifying the user that the theme has changed.
+        """
         msg_box = QMessageBox()
         msg_box.setIcon(QMessageBox.Icon.Information)
         msg_box.setWindowTitle("Theme Changed")
         msg_box.setText(f"Theme changed to {theme_name} successfully.")
+        
+        # Set window icon using a helper function for resource path
         msg_box.setWindowIcon(QIcon(resource_path("resources/icons/icon.ico")))
         msg_box.setStandardButtons(QMessageBox.StandardButton.Ok)
+        
+        # Use the current app stylesheet for consistency
         msg_box.setStyleSheet(self.app.styleSheet())
         msg_box.exec()
 
     def load_initial_theme(self):
-        """Carga el tema inicial sin mostrar notificación"""
+        """
+        Loads the initial theme from settings without showing a notification.
+        """
         theme_name = self.settings.value("selected_theme", "dark")
+        
+        # Fallback to default theme if the saved theme is not available
         if theme_name not in self.themes:
             theme_name = "dark"
         
         self.apply_theme(theme_name)
-        self.is_initial_load = False  # Marca que la carga inicial ha terminado
+        """
+        Mark that the initial load is complete so notifications can be shown later
+        """
+        self.is_initial_load = False
+        
+        # Return theme resources for further use if needed
         return load_theme(theme_name)

--- a/utils/menu_themes.py
+++ b/utils/menu_themes.py
@@ -6,78 +6,64 @@ from utils.helpers import load_theme
 
 class MenuThemes:
     def __init__(self, app, browser):
-        # Store references to the main application and browser window
         self.app = app
         self.browser = browser
-        # Persistent settings for saving the selected theme
         self.settings = QSettings("SampleBrowser", "SampleBrowserPro")
-        # List of available theme names
         self.themes = ["dark", "softBlue", "1bitMonitorGlow", "everglowDiamond"]
-        # Flag to track if the theme is being loaded for the first time
         self.is_initial_load = True
 
     def setup_menu(self):
-        """Creates the theme selection menu and adds it to the browser's menu bar."""
+        """Configura el menú de temas"""
         if self.browser is None:
             return
             
         menu_bar = QMenuBar(self.browser)
         themes_menu = menu_bar.addMenu("Themes")
 
-        # Add an action for each theme, connecting it to the selection handler
         for theme in self.themes:
             action = themes_menu.addAction(theme)
-            # Use a lambda to pass the theme name to the handler
             action.triggered.connect(lambda checked, t=theme: self.select_theme(t))
 
         self.browser.setMenuBar(menu_bar)
 
     def select_theme(self, selected_theme):
-        """Handles user theme selection, saves it, and applies the theme with notification."""
+        """Selección de tema por el usuario (con notificación)"""
         self.settings.setValue("selected_theme", selected_theme)
         self.apply_theme(selected_theme, show_notification=True)
 
     def apply_theme(self, theme_name, show_notification=False):
-        """Applies the selected theme to the app and browser, optionally showing a notification."""
+        """Aplica el tema con opción de mostrar notificación"""
         if self.app is None:
             return
             
-        # Load theme resources (stylesheet, image, progress bar style)
         stylesheet, image_path, progress_style = load_theme(theme_name)
         
-        # Apply stylesheet to the main app
         self.app.setStyleSheet(stylesheet)
         
-        # Apply stylesheet to the browser window if available
         if self.browser is not None:
             self.browser.setStyleSheet(stylesheet)
         
-        # Show notification only if not the initial load and notification is requested
+        # Solo muestra notificación si no es la carga inicial y está habilitado
         if show_notification and not self.is_initial_load:
             self.show_theme_changed_notification(theme_name)
 
     def show_theme_changed_notification(self, theme_name):
-        """Displays a message box notifying the user that the theme has changed."""
+        """Muestra notificación de cambio de tema"""
         msg_box = QMessageBox()
         msg_box.setIcon(QMessageBox.Icon.Information)
         msg_box.setWindowTitle("Theme Changed")
         msg_box.setText(f"Theme changed to {theme_name} successfully.")
-        # Set window icon using a helper function for resource path
         msg_box.setWindowIcon(QIcon(resource_path("resources/icons/icon.ico")))
         msg_box.setStandardButtons(QMessageBox.StandardButton.Ok)
-        # Use the current app stylesheet for consistency
         msg_box.setStyleSheet(self.app.styleSheet())
         msg_box.exec()
 
     def load_initial_theme(self):
-        """Loads the initial theme from settings without showing a notification."""
+        """Carga el tema inicial sin mostrar notificación"""
         theme_name = self.settings.value("selected_theme", "dark")
-        # Fallback to default theme if the saved theme is not available
         if theme_name not in self.themes:
             theme_name = "dark"
         
         self.apply_theme(theme_name)
-        # Mark that the initial load is complete so notifications can be shown later
-        self.is_initial_load = False
-        # Return theme resources for further use if needed
-        return
+        self.is_initial_load = False  # Marca que la carga inicial ha terminado
+        return load_theme(theme_name)


### PR DESCRIPTION
**Changes:** 

In **`menu_themes.py`**, an `is_initial_load` flag was implemented to avoid notifications at startup, error handling in `load_initial_theme()` was improved to always return a valid tuple, and the `show_notification` parameter was added in `apply_theme()` to control when notifications are displayed. 

In **`main.py`**, the initialization order was optimized: the theme is loaded first, then the main window (`SampleBrowser`) is created, and finally it is linked to the `ThemeManager`. A `try-except` block was added to handle errors when loading the theme, ensuring that the application does not crash even if there are style issues. 
